### PR TITLE
Fix SHELL and ENTRYPOINT missing -c

### DIFF
--- a/linux/ubuntu/act/Dockerfile
+++ b/linux/ubuntu/act/Dockerfile
@@ -71,7 +71,7 @@ RUN set -Eeuxo pipefail \
 # > Home repository
 LABEL org.opencontainers.image.source="https://github.com/catthehacker/docker_images"
 
-SHELL [ "/bin/bash", "--login" ]
+SHELL [ "/bin/bash", "--login", "-c" ]
 
 # > Force bash with environment
-ENTRYPOINT [ "/bin/bash", "--login" ]
+ENTRYPOINT [ "/bin/bash", "--login", "-c" ]

--- a/linux/ubuntu/runner/Dockerfile
+++ b/linux/ubuntu/runner/Dockerfile
@@ -93,7 +93,7 @@ USER ${RUNNER_USER}:${RUNNER_USER}
 
 WORKDIR /home/runner
 
-SHELL [ "/bin/bash", "--login" ]
+SHELL [ "/bin/bash", "--login", "-c" ]
 
 # > Force bash with environment
-ENTRYPOINT [ "/bin/bash", "--login" ]
+ENTRYPOINT [ "/bin/bash", "--login", "-c" ]


### PR DESCRIPTION
I noticed this error when I tried to both  execute the image with `docker run -it <image> bash`  and when I extended it and tried to run `apt-get` in my `Dockerfile`.