### PR TITLE
Build and push arm64 images for ubuntu 20.04

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -18,7 +18,6 @@ on:
 env:
   SLUG: ${{ github.repository_owner }}/ubuntu
   DISTRO: ubuntu
-  PLATFORMS: linux/amd64
   NODE: '14'
   BUILD_REF: ${{ github.sha }}
   SKIP_TEST: false
@@ -34,7 +33,17 @@ jobs:
       fail-fast: true
       max-parallel: 4
       matrix:
-        TAG: [latest, 20.04, 18.04, 16.04]
+        include:
+          - TAG: latest
+            PLATFORMS: linux/amd64,linux/arm64
+          - TAG: 20.04
+            PLATFORMS: linux/amd64,linux/arm64
+          - TAG: 18.04
+            PLATFORMS: linux/amd64
+          - TAG: 16.04
+            PLATFORMS: linux/amd64
+    env:
+      PLATFORMS: ${{ matrix.PLATFORMS }}
     steps:
       - name: Login to GitHub Container Registry
         if: ${{ github.repository_owner == github.actor }}
@@ -162,9 +171,27 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        TAG: [latest, 20.04, 18.04]
-        TYPE: [js, pwsh]
+        include:
+          - TAG: latest
+            TYPE: js
+            PLATFORMS: linux/amd64,linux/arm64
+          - TAG: latest
+            TYPE: pwsh
+            PLATFORMS: linux/amd64,linux/arm64
+          - TAG: 20.04
+            TYPE: js
+            PLATFORMS: linux/amd64,linux/arm64
+          - TAG: 20.04
+            TYPE: pwsh
+            PLATFORMS: linux/amd64,linux/arm64
+          - TAG: 18.04
+            TYPE: js
+            PLATFORMS: linux/amd64
+          - TAG: 18.04
+            TYPE: pwsh
+            PLATFORMS: linux/amd64
     env:
+      PLATFORMS: ${{ matrix.PLATFORMS }}
       BUILD_TAG: ${{ matrix.TYPE }}-${{ matrix.TAG }}
       TAG: ${{ matrix.TYPE }}-${{ matrix.TAG }}
       TYPE: ${{ matrix.TYPE }}

--- a/linux/ubuntu/scripts/act.sh
+++ b/linux/ubuntu/scripts/act.sh
@@ -90,10 +90,13 @@ printf "\n\t🐋 Installed moby-buildx 🐋\t\n"
 docker buildx version
 
 printf "\n\t🐋 Installing Node.JS 🐋\t\n"
+ARCH=$(uname -m)
+if [ "$ARCH" = x86_64 ]; then ARCH=x64; fi
+if [ "$ARCH" = aarch64 ]; then ARCH=arm64; fi
 VER=$(curl https://nodejs.org/download/release/index.json | jq "[.[] | select(.version|test(\"^v${NODE_VERSION}\"))][0].version" -r)
-NODEPATH="$AGENT_TOOLSDIRECTORY/node/${VER:1}/x64"
+NODEPATH="$AGENT_TOOLSDIRECTORY/node/${VER:1}/$ARCH"
 mkdir -v -m 0777 -p "$NODEPATH"
-curl -SsL "https://nodejs.org/download/release/latest-v${NODE_VERSION}.x/node-$VER-linux-x64.tar.xz" | tar -Jxf - --strip-components=1 -C "$NODEPATH"
+curl -SsL "https://nodejs.org/download/release/latest-v${NODE_VERSION}.x/node-$VER-linux-$ARCH.tar.xz" | tar -Jxf - --strip-components=1 -C "$NODEPATH"
 sed "s|^PATH=|PATH=$NODEPATH/bin:|mg" -i /etc/environment
 export PATH="$NODEPATH/bin:$PATH"
 

--- a/linux/ubuntu/scripts/go.sh
+++ b/linux/ubuntu/scripts/go.sh
@@ -21,7 +21,10 @@ for V in $(jq -r '.toolcache[] | select(.name == "go") | .versions[]' "/imagegen
   GOPATH="$AGENT_TOOLSDIRECTORY/go/${VER}/x64"
 
   mkdir -v -m 0777 -p "$GOPATH"
-  wget -qO- "https://golang.org/dl/go${VER}.linux-amd64.tar.gz" | tar -zxf - --strip-components=1 -C "$GOPATH"
+  ARCH=$(uname -m)
+  if [ "$ARCH" = x86_64 ]; then ARCH=amd64; fi
+  if [ "$ARCH" = aarch64 ]; then ARCH=arm64; fi
+  wget -qO- "https://golang.org/dl/go${VER}.linux-$ARCH.tar.gz" | tar -zxf - --strip-components=1 -C "$GOPATH"
 
   ENVVAR="${V//\./_}"
   echo "${ENVVAR}=${GOPATH}" >>/etc/environment

--- a/linux/ubuntu/scripts/js.sh
+++ b/linux/ubuntu/scripts/js.sh
@@ -23,7 +23,10 @@ for V in "${versions[@]}"; do
   # disable warning about 'mkdir -m -p'
   # shellcheck disable=SC2174
   mkdir -v -m 0777 -p "$NODEPATH"
-  wget -qO- "https://nodejs.org/download/release/latest-v${V}.x/node-$VER-linux-x64.tar.xz" | tar -Jxf - --strip-components=1 -C "$NODEPATH"
+  ARCH=$(uname -m)
+  if [ "$ARCH" = x86_64 ]; then ARCH=x64; fi
+  if [ "$ARCH" = aarch64 ]; then ARCH=arm64; fi
+  wget -qO- "https://nodejs.org/download/release/latest-v${V}.x/node-$VER-linux-$ARCH.tar.xz" | tar -Jxf - --strip-components=1 -C "$NODEPATH"
 
   ENVVAR="${V//\./_}"
   echo "${ENVVAR}=${NODEPATH}" >>/etc/environment


### PR DESCRIPTION
I wanted to use these images on my RaspberryPi computers with arm64 architecture and these are the changes I made to make the build system build and publish image manifest that also includes an arm64 entry.

Arm64 compatibility fail on ubuntu 16.04 and 18.04 because the apt-get packages don't include arm64 binaries for as many packages and fail due  to that. I opted to not try to mitigate that but instead opted out from building arm64 images for ubuntu 16.04 and 18.04.