### PR TITLE
Allow the cached go to be used by actions/setup-go

### DIFF
--- a/linux/ubuntu/scripts/go.sh
+++ b/linux/ubuntu/scripts/go.sh
@@ -34,6 +34,9 @@ for V in $(jq -r '.toolcache[] | select(.name == "go") | .versions[]' "/imagegen
   # ENVVAR="${V//\./_}"
   # echo "${ENVVAR}=${GOPATH}" >>/etc/environment
 
+  # Create a complete file
+  touch "${GOPATH}.complete"
+
   printf "\n\t🐋 Installed GO 🐋\t\n"
   "$GOPATH/bin/go" version
 


### PR DESCRIPTION
To be compatible with https://github.com/actions/toolkit/tree/main/packages/cache, create a .complete file, as we do in https://github.com/catthehacker/docker_images/blob/master/linux/ubuntu/scripts/java-tools.sh#L94