### PR TITLE
fix act failure when the git command is used in the workflow job

### DIFF
--- a/linux/ubuntu/scripts/act.sh
+++ b/linux/ubuntu/scripts/act.sh
@@ -68,6 +68,8 @@ apt-get install -y git
 
 git --version
 
+git config --system --add safe.directory '*'
+
 wget https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh -qO- | bash
 apt-get update
 apt-get install -y git-lfs


### PR DESCRIPTION
In act, `action/checkout` does not perform an actual repository checkout; instead, it copies (`docker cp`) local files.
During this process, the local UID/GID of the file or directory is preserved.

For security reasons, git does not operate in repositories where the owner is not the same as the user.
In the `ubuntu:act-latest` image, jobs are executed with the root user.
However, the repository copied by `action/checkout` is not owned by the root, which prevents the use of the git command.

To address this, we need to configure `safe.directory`.
In GitHub Actions, git config includes `safe.directory=*`.

For more details, please refer to my example: https://github.com/makiuchi-d/act-fail-example