### PR TITLE
Remove RSA restriction from SSH (closes #115)

### DIFF
--- a/linux/ubuntu/scripts/act.sh
+++ b/linux/ubuntu/scripts/act.sh
@@ -93,8 +93,8 @@ printf "\n\t🐋 Updated apt lists and upgraded packages 🐋\t\n"
 printf "\n\t🐋 Creating ~/.ssh and adding 'github.com' 🐋\t\n"
 mkdir -m 0700 -p ~/.ssh
 {
-  ssh-keyscan -t rsa github.com
-  ssh-keyscan -t rsa ssh.dev.azure.com
+  ssh-keyscan github.com
+  ssh-keyscan ssh.dev.azure.com
 } >>/etc/ssh/ssh_known_hosts
 
 printf "\n\t🐋 Installed base utils 🐋\t\n"


### PR DESCRIPTION
Please see #115 - this removes RSA from being the only supported encryption method, which breaks newer, better practices for encryption, and allows for this script to update to GitHub's newer standards as they update.

Full list of fingerprints are available here, which this new code will now properly incorporate into the known hosts:

https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints