### PR TITLE
Build rust images for ARM64 & use `cargo binstall` for faster build time

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -229,7 +229,7 @@ jobs:
             TYPE: js
           - PLATFORMS: linux/amd64,linux/arm64
             TYPE: pwsh
-          - PLATFORMS: linux/amd64
+          - PLATFORMS: linux/amd64,linux/arm64
             TYPE: rust
           - PLATFORMS: linux/amd64,linux/arm64
             TYPE: dotnet

--- a/linux/ubuntu/scripts/rust.sh
+++ b/linux/ubuntu/scripts/rust.sh
@@ -20,7 +20,11 @@ source "${CARGO_HOME}/env"
 
 rustup component add rustfmt clippy
 
-cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
+printf "\n\t🐋 Installing cargo-binstall 🐋\t\n"
+# Pinned to commit-hash for latest release v1.4.7 to prevent accidental problems
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/f6a95fa733be466c0e66c360f52e1d6998e47f25/install-from-binstall-release.sh | bash
+
+cargo binstall -y bindgen-cli cbindgen cargo-audit cargo-outdated
 
 chmod -R 777 "$(dirname "${RUSTUP_HOME}")"
 


### PR DESCRIPTION
Hi,

I wanted to use `act` on an M1 MacBook, but noticed that the `rust` flavor doesn't have an image on Docker Hub for linux/arm64. This is unfortunate, since running amd64 `rustc` through QEMU often leads to segfaults and other crashes, and is pretty slow.

My guess is the reason for this situation is similar -- building the rust variant on the amd64 GH Actions runners takes way too long and times out.

Hence I switched the image building variant to install [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) instead of installing from source.

I hope this is well-received ;)

Here's an example build run I did: https://github.com/cfstras/docker_images/actions/runs/7221756769