### PR TITLE
move tools out of /opt/hostedtoolcache

### DIFF
--- a/linux/ubuntu/scripts/act.sh
+++ b/linux/ubuntu/scripts/act.sh
@@ -21,6 +21,7 @@ node_arch() {
 
 ImageOS=ubuntu$(echo "${VERSION_ID}" | cut -d'.' -f 1)
 AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+ACT_TOOLSDIRECTORY=/opt/acttoolcache
 {
   echo "IMAGE_OS=$ImageOS"
   echo "ImageOS=$ImageOS"
@@ -30,10 +31,13 @@ AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
   echo "DEPLOYMENT_BASEPATH=/opt/runner"
   echo "USER=$(whoami)"
   echo "RUNNER_USER=$(whoami)"
+  echo "ACT_TOOLSDIRECTORY=${ACT_TOOLSDIRECTORY}"
 } | tee -a "/etc/environment"
 
 mkdir -m 0777 -p "${AGENT_TOOLSDIRECTORY}"
 chown -R 1001:1000 "${AGENT_TOOLSDIRECTORY}"
+mkdir -m 0777 -p "${ACT_TOOLSDIRECTORY}"
+chown -R 1001:1000 "${ACT_TOOLSDIRECTORY}"
 
 mkdir -m 0777 -p /github
 chown -R 1001:1000 /github
@@ -121,7 +125,7 @@ IFS=' ' read -r -a NODE <<<"$NODE_VERSION"
 for ver in "${NODE[@]}"; do
   printf "\n\t🐋 Installing Node.JS=%s 🐋\t\n" "${ver}"
   VER=$(curl https://nodejs.org/download/release/index.json | jq "[.[] | select(.version|test(\"^v${ver}\"))][0].version" -r)
-  NODEPATH="$AGENT_TOOLSDIRECTORY/node/${VER:1}/$(node_arch)"
+  NODEPATH="${ACT_TOOLSDIRECTORY}/node/${VER:1}/$(node_arch)"
   mkdir -v -m 0777 -p "$NODEPATH"
   wget "https://nodejs.org/download/release/latest-v${ver}.x/node-$VER-linux-$(node_arch).tar.xz" -O "node-$VER-linux-$(node_arch).tar.xz"
   tar -Jxf "node-$VER-linux-$(node_arch).tar.xz" --strip-components=1 -C "$NODEPATH"

--- a/linux/ubuntu/scripts/dotnet.sh
+++ b/linux/ubuntu/scripts/dotnet.sh
@@ -5,6 +5,8 @@
 ##         Must be run as non-root user after homebrew
 ################################################################################
 
+. /etc/environment
+
 # Install dotnet CLI
 . /imagegeneration/installers/helpers/etc-environment.sh
 
@@ -12,10 +14,10 @@ printf "\n\t🐋 Installing .NET 🐋\t\n"
 #apt-get install -y dotnet-sdk-7.0 dotnet-sdk-6.0 dotnet-runtime-7.0 dotnet-runtime-6.0
 curl -LO https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh
 cat ./dotnet-install.sh
-bash ./dotnet-install.sh --install-dir /opt/hostedtoolcache/dotnet --no-path --channel STS  # net 7.0
-bash ./dotnet-install.sh --install-dir /opt/hostedtoolcache/dotnet --no-path --channel LTS  # net 6.0
+bash ./dotnet-install.sh --install-dir ${ACT_TOOLSDIRECTORY}/dotnet --no-path --channel STS  # net 7.0
+bash ./dotnet-install.sh --install-dir ${ACT_TOOLSDIRECTORY}/dotnet --no-path --channel LTS  # net 6.0
 rm ./dotnet-install.sh
-export DOTNET_ROOT=/opt/hostedtoolcache/dotnet
+export DOTNET_ROOT=${ACT_TOOLSDIRECTORY}/dotnet
 export PATH=$PATH:$DOTNET_ROOT
 {
   echo "DOTNET_ROOT=${DOTNET_ROOT}"

--- a/linux/ubuntu/scripts/go.sh
+++ b/linux/ubuntu/scripts/go.sh
@@ -29,7 +29,7 @@ DEFVER=$(jq -r '.toolcache[] | select(.name == "go") | .default' "/imagegenerati
 for V in $(jq -r '.toolcache[] | select(.name == "go") | .versions[]' "/imagegeneration/toolset.json"); do
   printf "\n\t🐋 Installing GO=%s 🐋\t\n" "${V}"
   VER=$(jq -r "[.[] | select(.version|test(\"^${V}\"))][0].version" "/tmp/go-toolset.json")
-  GOPATH="$AGENT_TOOLSDIRECTORY/go/${VER}/$(toolcache_arch)"
+  GOPATH="${ACT_TOOLSDIRECTORY}/go/${VER}/$(toolcache_arch)"
 
   mkdir -v -m 0777 -p "$GOPATH"
   DL_VER="${VER}"

--- a/linux/ubuntu/scripts/java-tools.sh
+++ b/linux/ubuntu/scripts/java-tools.sh
@@ -101,7 +101,7 @@ installOpenJDK() {
         exit 1
     fi
 
-    JAVA_TOOLCACHE_PATH="${AGENT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk"
+    JAVA_TOOLCACHE_PATH="${ACT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk"
 
     fullJavaVersion=$(cat "${javaVersionPath}/release" | grep "^SEMANTIC" | cut -d "=" -f 2 | tr -d "\"" | tr "+" "-")
 

--- a/linux/ubuntu/scripts/js.sh
+++ b/linux/ubuntu/scripts/js.sh
@@ -27,7 +27,7 @@ JSON=$(wget -qO- https://nodejs.org/download/release/index.json | jq --compact-o
 for V in "${versions[@]}"; do
   printf "\n\t🐋 Installing NODE=%s 🐋\t\n" "${V}"
   VER=$(echo "${JSON}" | jq "[.[] | select(.version|test(\"^v${V}\"))][0].version" -r)
-  NODEPATH="$AGENT_TOOLSDIRECTORY/node/${VER:1}/x64"
+  NODEPATH="${ACT_TOOLSDIRECTORY}/node/${VER:1}/x64"
 
   mkdir -v -m 0777 -p "$NODEPATH"
   ARCH=$(uname -m)


### PR DESCRIPTION
Mounting `/opt/hostedtoolcache` can cause inconsistent content on the act-toolcache volume, to avoid problems move the content.