### PR TITLE
Add ~/.local/bin to PATH.

### DIFF
--- a/linux/ubuntu/scripts/act.sh
+++ b/linux/ubuntu/scripts/act.sh
@@ -166,6 +166,10 @@ for SCRIPT in "${scripts[@]}"; do
   "/imagegeneration/installers/${SCRIPT}.sh"
 done
 
+printf "\n\t🐋 Creating ~/.local/bin and adding to PATH 🐋\t\n"
+mkdir -m 0755 -p "${HOME}/.local/bin"
+sed "s|^PATH=|PATH=${HOME}/.local/bin:|mg" -i /etc/environment
+
 printf "\n\t🐋 Cleaning image 🐋\t\n"
 apt-get clean
 rm -rf /var/cache/* /var/log/* /var/lib/apt/lists/* /tmp/* || echo 'Failed to delete directories'

--- a/linux/ubuntu/scripts/runner.sh
+++ b/linux/ubuntu/scripts/runner.sh
@@ -41,6 +41,11 @@ mkdir -m 0700 -p "/home/${RUNNER}/.ssh"
 chmod 644 "/home/${RUNNER}/.ssh/known_hosts"
 chown -R "${RUNNER}":"${RUNNER}" "/home/${RUNNER}/.ssh"
 
+mkdir -m 0755 -p "/home/${RUNNER}/.local/bin"
+chown -R "${RUNNER}":"${RUNNER}" "/home/${RUNNER}/.local"
+sed '/^PATH=/s,\([=:]\)/root/.local/bin\(:\|$\),\1,g' -i /etc/environment
+sed "s,^PATH=,PATH=/home/${RUNNER}/.local/bin:," -i /etc/environment
+
 . /etc/environment
 
 # Word is of the form "A"B"C" (B indicated). Did you mean "ABC" or "A\"B\"C"?shellcheck(SC2140)


### PR DESCRIPTION
Python's pip and pipx put executable for user-installed modules into ~/.local/bin.  Also the XDG basedir specification recommends adding it to PATH, so this may help more than just Python.

Normally on Ubuntu, this is handled by the ~/.profile that's copied from /etc/skel.  But since we don't have normal shell initialization, we need to add it to the PATH set in /etc/environment.

Fixes #128.