### PR TITLE
Add missing `ubuntu:*-24.04` imgs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,29 +22,34 @@
     - The friendly tag name version in the output can be looked up here https://github.com/actions/runner-images/releases to find out more about the sources
   - available tags are
     - `ghcr.io/catthehacker/ubuntu:full-latest` (aka `full-22.04`)
-    - `ghcr.io/catthehacker/ubuntu:full-24.04` (beta image)
+    - `ghcr.io/catthehacker/ubuntu:full-24.04` (beta)
     - `ghcr.io/catthehacker/ubuntu:full-22.04`
     - `ghcr.io/catthehacker/ubuntu:full-20.04` (Updated as long ubuntu-20.04 free public GitHub Hosted Runners are available)
 
 - [`/linux/ubuntu/act`](./linux/ubuntu/scripts/act.sh) - image used in [github.com/nektos/act][nektos/act] as medium size image retaining compatibility with most actions while maintaining small size
   - `ghcr.io/catthehacker/ubuntu:act-20.04`
   - `ghcr.io/catthehacker/ubuntu:act-22.04`
+  - `ghcr.io/catthehacker/ubuntu:act-24.04` (beta)
   - `ghcr.io/catthehacker/ubuntu:act-latest`
 - [`/linux/ubuntu/runner`](./linux/ubuntu/scripts/runner.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `runner` as user instead of `root`
   - `ghcr.io/catthehacker/ubuntu:runner-20.04`
   - `ghcr.io/catthehacker/ubuntu:runner-22.04`
+  - `ghcr.io/catthehacker/ubuntu:runner-24.04` (beta)
   - `ghcr.io/catthehacker/ubuntu:runner-latest`
 - [`/linux/ubuntu/js`](./linux/ubuntu/scripts/js.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `js` tools installed (`yarn`, `nvm`, `node` v16/v18, `pnpm`, `grunt`, etc.)
   - `ghcr.io/catthehacker/ubuntu:js-20.04`
   - `ghcr.io/catthehacker/ubuntu:js-22.04`
+  - `ghcr.io/catthehacker/ubuntu:js-24.04` (beta)
   - `ghcr.io/catthehacker/ubuntu:js-latest`
 - [`/linux/ubuntu/rust`](./linux/ubuntu/scripts/rust.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `rust` tools installed (`rustfmt`, `clippy`, `cbindgen`, etc.)
   - `ghcr.io/catthehacker/ubuntu:rust-20.04`
   - `ghcr.io/catthehacker/ubuntu:rust-22.04`
+  - `ghcr.io/catthehacker/ubuntu:rust-24.04` (beta)
   - `ghcr.io/catthehacker/ubuntu:rust-latest`
 - [`/linux/ubuntu/pwsh`](./linux/ubuntu/scripts/pwsh.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `pwsh` tools and modules installed
   - `ghcr.io/catthehacker/ubuntu:pwsh-20.04`
   - `ghcr.io/catthehacker/ubuntu:pwsh-22.04`
+  - `ghcr.io/catthehacker/ubuntu:pwsh-24.04` (beta)
   - `ghcr.io/catthehacker/ubuntu:pwsh-latest`
 
 ## [`ubuntu-18.04` has been deprecated and images for that environment will not be updated anymore](https://github.com/actions/runner-images/issues/6002)


### PR DESCRIPTION
It seems that some Ubuntu 24.04 images were mistakenly left out of the README. It took me a moment to find them, so here's a quick PR to increase visibility.

I noted that each is in "beta" - though I'm not sure if that's still true. If not, please let me know and I'll remove it. Thank you for your hard work on this project! :D

## Changes

- Adds the various Ubuntu 22.04 images to the README

## Checklist

- [x] ...I added them
- [x] kept formatting the same