### PR TITLE
feat(workflow): Provide extra ARM64 images as `full-*-arm` tags

### DIFF
--- a/.github/workflows/copy-full-image.yml
+++ b/.github/workflows/copy-full-image.yml
@@ -34,8 +34,6 @@ jobs:
           dest: full-24.04
         - src: ghcr.io/christopherhx/runner-images:ubuntu22-runner-large-${{ inputs.version || 'latest' }}
           dest: full-22.04
-        - src: ghcr.io/christopherhx/runner-images:ubuntu20-runner-large-${{ inputs.version || 'latest' }}
-          dest: full-20.04
     steps:
       - name: Force SLUG to lowercase
         uses: actions/github-script@v6

--- a/.github/workflows/copy-full-image.yml
+++ b/.github/workflows/copy-full-image.yml
@@ -28,7 +28,7 @@ jobs:
       max-parallel: 1
       matrix:
         copy:
-        - src: ghcr.io/christopherhx/runner-images:ubuntu22-runner-large-${{ inputs.version || 'latest' }}
+        - src: ghcr.io/christopherhx/runner-images:ubuntu24-runner-large-${{ inputs.version || 'latest' }}
           dest: full-latest
         - src: ghcr.io/christopherhx/runner-images:ubuntu24-runner-large-${{ inputs.version || 'latest' }}
           dest: full-24.04

--- a/.github/workflows/copy-full-image.yml
+++ b/.github/workflows/copy-full-image.yml
@@ -34,6 +34,10 @@ jobs:
           dest: full-24.04
         - src: ghcr.io/christopherhx/runner-images:ubuntu22-runner-large-${{ inputs.version || 'latest' }}
           dest: full-22.04
+        - src: ghcr.io/christopherhx/runner-images:ubuntu24-runner-large-${{ inputs.version || 'latest' }}-arm
+          dest: full-24.04-arm
+        - src: ghcr.io/christopherhx/runner-images:ubuntu22-runner-large-${{ inputs.version || 'latest' }}-arm
+          dest: full-22.04-arm
     steps:
       - name: Force SLUG to lowercase
         uses: actions/github-script@v6


### PR DESCRIPTION
## What's changed

- Bump base image of `full-latest` tag: `ubuntu{22 => 24}-runner-large-latest`.
- Drop `full-20.04` tag, since GitHub does not provide this runner image any more.
- Add 2 new tags, simulating `linux/arm64` version of GitHub Runners.
  - `full-24.04-arm`, use `ghcr.io/christopherhx/runner-images:ubuntu24-runner-large-latest-arm` as base.
    - Image was exported from [`ubuntu-24.04-arm`](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md), provided by **Arm Limited** in [actions/partner-runner-images](https://github.com/actions/partner-runner-images)
  - `full-22.04-arm`, use `ghcr.io/christopherhx/runner-images:ubuntu22-runner-large-latest-arm` as base.
    - Image was exported from [`ubuntu-22.04-arm`](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md), provided by **Arm Limited** in [actions/partner-runner-images](https://github.com/actions/partner-runner-images)

## Additional information

- Resolve #149