### PR TITLE
README.md - document `latest` pointing to `22.04`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,43 +28,43 @@
 - [`/linux/ubuntu/act`](./linux/ubuntu/scripts/act.sh) - image used in [github.com/nektos/act][nektos/act] as medium size image retaining compatibility with most actions while maintaining small size
   - `ghcr.io/catthehacker/ubuntu:act-22.04`
   - `ghcr.io/catthehacker/ubuntu:act-24.04`
-  - `ghcr.io/catthehacker/ubuntu:act-latest`
+  - `ghcr.io/catthehacker/ubuntu:act-latest` (aka `act-22.04`)
 - [`/linux/ubuntu/runner`](./linux/ubuntu/scripts/runner.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `runner` as user instead of `root`
   - `ghcr.io/catthehacker/ubuntu:runner-22.04`
   - `ghcr.io/catthehacker/ubuntu:runner-24.04`
-  - `ghcr.io/catthehacker/ubuntu:runner-latest`
+  - `ghcr.io/catthehacker/ubuntu:runner-latest` (aka `runner-22.04`)
 - [`/linux/ubuntu/js`](./linux/ubuntu/scripts/js.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `js` tools installed (`yarn`, `nvm`, `node` v16/v18, `pnpm`, `grunt`, etc.)
   - `ghcr.io/catthehacker/ubuntu:js-22.04`
   - `ghcr.io/catthehacker/ubuntu:js-24.04`
-  - `ghcr.io/catthehacker/ubuntu:js-latest`
+  - `ghcr.io/catthehacker/ubuntu:js-latest` (aka `js-22.04`)
 - [`/linux/ubuntu/rust`](./linux/ubuntu/scripts/rust.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `rust` tools installed (`rustfmt`, `clippy`, `cbindgen`, etc.)
   - `ghcr.io/catthehacker/ubuntu:rust-22.04`
   - `ghcr.io/catthehacker/ubuntu:rust-24.04`
-  - `ghcr.io/catthehacker/ubuntu:rust-latest`
+  - `ghcr.io/catthehacker/ubuntu:rust-latest` (aka `rust-22.04`)
 - [`/linux/ubuntu/pwsh`](./linux/ubuntu/scripts/pwsh.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `pwsh` tools and modules installed
   - `ghcr.io/catthehacker/ubuntu:pwsh-22.04`
   - `ghcr.io/catthehacker/ubuntu:pwsh-24.04`
-  - `ghcr.io/catthehacker/ubuntu:pwsh-latest`
+  - `ghcr.io/catthehacker/ubuntu:pwsh-latest` (aka `pwsh-22.04`)
 - [`/linux/ubuntu/go`](./linux/ubuntu/scripts/go.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `go` tools installed
   - `ghcr.io/catthehacker/ubuntu:go-22.04`
   - `ghcr.io/catthehacker/ubuntu:go-24.04`
-  - `ghcr.io/catthehacker/ubuntu:go-latest`
+  - `ghcr.io/catthehacker/ubuntu:go-latest` (aka `go-22.04`)
 - [`/linux/ubuntu/dotnet`](./linux/ubuntu/scripts/dotnet.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with `.NET` tools installed
   - `ghcr.io/catthehacker/ubuntu:dotnet-22.04`
   - `ghcr.io/catthehacker/ubuntu:dotnet-24.04`
-  - `ghcr.io/catthehacker/ubuntu:dotnet-latest`
+  - `ghcr.io/catthehacker/ubuntu:dotnet-latest` (aka `dotnet-22.04`)
 - [`/linux/ubuntu/java-tools`](./linux/ubuntu/scripts/java-tools.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with Java tools installed
   - `ghcr.io/catthehacker/ubuntu:java-tools-22.04`
   - `ghcr.io/catthehacker/ubuntu:java-tools-24.04`
-  - `ghcr.io/catthehacker/ubuntu:java-tools-latest`
+  - `ghcr.io/catthehacker/ubuntu:java-tools-latest` (aka `java-tools-22.04`)
 - [`/linux/ubuntu/gh`](./linux/ubuntu/scripts/gh.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with GitHub CLI tools installed
   - `ghcr.io/catthehacker/ubuntu:gh-22.04`
   - `ghcr.io/catthehacker/ubuntu:gh-24.04`
-  - `ghcr.io/catthehacker/ubuntu:gh-latest`
+  - `ghcr.io/catthehacker/ubuntu:gh-latest` (aka `gh-22.04`)
 - [`/linux/ubuntu/custom`](./linux/ubuntu/scripts/custom.sh) - `ghcr.io/catthehacker/ubuntu:act-*` but with custom tools installed
   - `ghcr.io/catthehacker/ubuntu:custom-22.04`
   - `ghcr.io/catthehacker/ubuntu:custom-24.04`
-  - `ghcr.io/catthehacker/ubuntu:custom-latest`
+  - `ghcr.io/catthehacker/ubuntu:custom-latest` (aka `custom-22.04`)
 
 ## [`ubuntu-20.04` has been deprecated and images for that environment will not be updated anymore](https://github.com/actions/runner-images/pull/11748)
 


### PR DESCRIPTION
Just to make clear for new users coming to the repo that `latest` is currently pointing to older version (which is unusual, so better to make it expllicit).